### PR TITLE
Reset nextRowNum when adding a new sheet

### DIFF
--- a/src/main/groovy/org/gsheets/building/WorkbookBuilder.groovy
+++ b/src/main/groovy/org/gsheets/building/WorkbookBuilder.groovy
@@ -64,6 +64,7 @@ class WorkbookBuilder {
 		assert closure
 
 		currentSheet = wb.createSheet(name)
+		nextRowNum = 0
 		closure.delegate = currentSheet
 		closure.call()
 		currentSheet


### PR DESCRIPTION
If you do:

``` groovy
@Grab( 'org.gsheets.kktec:gsheets:0.3.2a' )
import org.gsheets.building.*

def map = [ a:[ [ 1, 2, 3 ], [  4,  5,  6 ] ],
            b:[ [ 7, 8, 9 ], [ 10, 11, 12 ] ] ]

new WorkbookBuilder( true ).with { wb ->
    def book = wb.workbook { 
        map.each { name, values ->
            sheet( name ) {
                values.each { 
                    row( it )
                }
            }
        }
    }
    new File( '/tmp/test.xlsx' ).withOutputStream { os ->
        book.write( os )
    }
}
```

When you open `/tmp/test.xlsx`, you'll notice that the rows for sheet `b` start at row `3` in Excel
